### PR TITLE
RT#98113 Fix overload fallback on perl 5.10.x

### DIFF
--- a/lib/Type/Coercion.pm
+++ b/lib/Type/Coercion.pm
@@ -24,8 +24,10 @@ use overload
 
 BEGIN {
 	require Type::Tiny;
-	overload->import(q(~~) => sub { $_[0]->has_coercion_for_value($_[1]) })
-		if Type::Tiny::SUPPORT_SMARTMATCH();
+	overload->import(
+		q(~~)    => sub { $_[0]->has_coercion_for_value($_[1]) },
+		fallback => 1, # 5.10 loses the fallback otherwise
+	) if Type::Tiny::SUPPORT_SMARTMATCH();
 }
 
 sub _overload_coderef

--- a/lib/Type/Tiny.pm
+++ b/lib/Type/Tiny.pm
@@ -86,8 +86,10 @@ use overload
 	fallback   => 1,
 ;
 BEGIN {
-	overload->import(q(~~) => sub { $_[0]->check($_[1]) })
-		if Type::Tiny::SUPPORT_SMARTMATCH;
+	overload->import(
+		q(~~)    => sub { $_[0]->check($_[1]) },
+		fallback => 1, # 5.10 loses the fallback otherwise
+	) if Type::Tiny::SUPPORT_SMARTMATCH;
 }
 
 sub _overload_coderef

--- a/t/40-regression/rt98113.t
+++ b/t/40-regression/rt98113.t
@@ -1,0 +1,52 @@
+=pod
+
+=encoding utf-8
+
+=head1 PURPOSE
+
+Test overload fallback
+
+=head1 SEE ALSO
+
+L<https://rt.cpan.org/Ticket/Display.html?id=98113>.
+
+=head1 DEPENDENCIES
+
+Uses the bundled BiggerLib.pm type library.
+
+=head1 AUTHOR
+
+Dagfinn Ilmari Mannsåker E<lt>ilmari@ilmari.orgE<gt>.
+
+=head1 COPYRIGHT AND LICENCE
+
+This software is copyright (c) 2014 by Dagfinn Ilmari Mannsåker
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+
+=cut
+
+use strict;
+use warnings;
+use lib qw( ./lib ./t/lib ../inc ./inc );
+
+use Test::More;
+use Test::Fatal;
+
+use BiggerLib -types, -coercions;
+
+is(
+	exception { no warnings 'numeric'; BigInteger + 42 },
+	undef,
+	'Type::Tiny overload fallback works',
+);
+
+is(
+	exception { BigInteger->coercion eq '1' },
+	undef,
+	'Type::Coercion overload fallback works',
+);
+
+done_testing;


### PR DESCRIPTION
Subsequent overload->import calls clobber the existing fallback value,
so make sure to repeat it when we do call ->import again.
