### PR TITLE
Fix "Malformed UTF-8 character" warnings on old perls

### DIFF
--- a/lib/Type/Params.pm
+++ b/lib/Type/Params.pm
@@ -158,7 +158,7 @@ sub compile
 					? $constraint->type_parameter->inline_check($varname)
 					: $constraint->inline_check($varname),
 				$constraint->{uniq},
-				B::perlstring($constraint),
+				B::cstring($constraint),
 				$varname,
 				$is_slurpy ? 'q{$SLURPY}' : sprintf('q{$_[%d]}', $arg),
 			);
@@ -172,7 +172,7 @@ sub compile
 				'%s or Type::Tiny::_failed_check(%d, %s, %s, varname => %s);',
 				sprintf(sprintf '$check[%d]->(%s)', $arg, $varname),
 				$constraint->{uniq},
-				B::perlstring($constraint),
+				B::cstring($constraint),
 				$varname,
 				$is_slurpy ? 'q{$SLURPY}' : sprintf('q{$_[%d]}', $arg),
 			);

--- a/t/40-regression/rt101582.t
+++ b/t/40-regression/rt101582.t
@@ -1,0 +1,46 @@
+=pod
+
+=encoding utf-8
+
+=head1 PURPOSE
+
+Fix "Malformed UTF-8 character" warnings in Perl 5.10 with utf8 pragma on
+
+=head1 SEE ALSO
+
+L<https://rt.cpan.org/Ticket/Display.html?id=101582>.
+
+=head1 AUTHOR
+
+André Walker <andre@cpan.org>
+
+=head1 COPYRIGHT AND LICENCE
+
+This software is copyright (c) 2015 by André Walker
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut
+
+use strict;
+use warnings;
+use utf8;
+
+use Test::More;
+use Test::Fatal;
+
+use Types::Standard qw/Dict Int/; # could've been anything instead of Int
+use Type::Params qw/compile/;
+use Test::More;
+use Test::Fatal;
+
+local $SIG{__WARN__} = sub { die @_ };
+
+unlike(
+    exception { compile( Dict [ foo => Int ] ) },
+    qr/Malformed UTF-8 character/,
+    q/Didn't get the "Malformed UTF-8" warning/,
+);
+
+done_testing;


### PR DESCRIPTION
As per https://rt.cpan.org/Ticket/Display.html?id=101582, the following code in Perl 5.10:

``` perl
use utf8;
use Types::Standard qw/Dict Int/;
use Type::Params qw/compile/;
compile( Dict [ foo => Int ] );
```

Will generate the following output:

```
Malformed UTF-8 character (unexpected continuation byte 0xb8, with no preceding start byte) in subroutine entry at lib/Type/Params.pm line 155.
Malformed UTF-8 character (unexpected non-continuation byte 0x3b, immediately after start byte 0xd0) in subroutine entry at lib/Type/Params.pm line 155.
Malformed UTF-8 character (unexpected non-continuation byte 0x78, immediately after start byte 0xf8) in subroutine entry at lib/Type/Params.pm line 155.
Malformed UTF-8 character (unexpected non-continuation byte 0x3b, immediately after start byte 0xd0) in subroutine entry at lib/Type/Params.pm line 155.
Malformed UTF-8 character (unexpected non-continuation byte 0x3b, immediately after start byte 0xd0) in subroutine entry at lib/Type/Params.pm line 155.
Malformed UTF-8 character (unexpected continuation byte 0xb8, with no preceding start byte) in subroutine entry at lib/Type/Params.pm line 155.
...
(goes on for thousands of lines)
```

Example: https://travis-ci.org/andrewalker/p5-webservice-digitalocean/jobs/47282523

I have now tested and confirmed that older versions of Perl (5.8, 5.6) **also fail**.

After 5.10, `B::perlstring()` was made an alias to `B::cstring()`, as shown in this commit:

http://perl5.git.perl.org/perl.git/commitdiff/84556172294db864f27a4b5df6dac9127e1e7205

If we replace all instances of `B::perlstring` with `B::cstring` in the "compile" subroutine in Test::Params, the issue goes away, and all tests pass.

Please tell me if this solution is OK for you, and if I should replace all other cases of `perlstring` with `cstring`. If this is a bad idea, would you help me find another solution?
