### PR TITLE
Ensure Moose is at or above 2.000 in t/02-api.t

### DIFF
--- a/t/02-api.t
+++ b/t/02-api.t
@@ -25,6 +25,7 @@ use warnings;
 use Test::More;
 
 my $HAVE_MOOSE = eval { require Moose };
+$HAVE_MOOSE = 0 if $Moose::VERSION < '2.000';
 
 my @MOOSE_WANTS = qw(
 	_actually_compile_type_constraint


### PR DESCRIPTION
This was causing tests to fail on a system with an abysmally old Moose 
installed.  The other tests checked that Moose was at least at version 2.000, 
so we check for that here as well.
