### PR TITLE
Support whitespaces for NumericCode

### DIFF
--- a/lib/Types/Common/String.pm
+++ b/lib/Types/Common/String.pm
@@ -60,7 +60,7 @@ $meta->add_type(
 );
 
 NumericCode->coercion->add_type_coercions(
-	NonEmptySimpleStr, q[ do { (my $code = $_) =~ s/[[:punct:]]//g; $code } ],
+	NonEmptySimpleStr, q[ do { (my $code = $_) =~ s/[[:punct:][:space:]]//g; $code } ],
 );
 
 $meta->add_type(

--- a/t/20-unit/Types-Common-String/coerce.t
+++ b/t/20-unit/Types-Common-String/coerce.t
@@ -54,5 +54,6 @@ is(to_UpperCaseStr('foo'), 'FOO', 'uppercase str' );
 is(to_LowerCaseStr('BAR'), 'bar', 'lowercase str' );
 
 is(to_NumericCode('4111-1111-1111-1111'), '4111111111111111', 'numeric code' );
+is(to_NumericCode('+1 (800) 555-01-23'), '18005550123', 'numeric code' );
 
 done_testing;


### PR DESCRIPTION
This was added to `MooseX::Types::Common`. See moose/MooseX-Types-Common#3.
