### PR TITLE
Give good error location in error message from Moo isa validation

### DIFF
--- a/lib/Error/TypeTiny.pm
+++ b/lib/Error/TypeTiny.pm
@@ -60,10 +60,13 @@ sub throw
 		my ($pkg, $func) = ($1 =~ m{^(.+)::(\w+)$});
 		$level++ if caller($level) eq ($pkg||"");
 	}
+        # Moo's Method::Generate::Constructor puts an eval in the stack trace,
+        # that is useless for debugging, so show the stack frame one above.
         $level++
             if (
-                caller($level) eq "Method::Generate::Constructor" &&
-                (caller($level))[1] =~ /\(eval \d+\)/
+                (caller($level))[1] =~ /^\(eval \d+\)$/ &&
+                # (caller())[3] is $subroutine
+                (caller($level))[3] eq '(eval)'
             );
 	@ctxt{qw/ package file line /} = caller($level);
 	

--- a/lib/Error/TypeTiny.pm
+++ b/lib/Error/TypeTiny.pm
@@ -60,6 +60,11 @@ sub throw
 		my ($pkg, $func) = ($1 =~ m{^(.+)::(\w+)$});
 		$level++ if caller($level) eq ($pkg||"");
 	}
+        $level++
+            if (
+                caller($level) eq "Method::Generate::Constructor" &&
+                (caller($level))[1] =~ /\(eval \d+\)/
+            );
 	@ctxt{qw/ package file line /} = caller($level);
 	
 	my $stack = undef;

--- a/t/20-unit/Error-TypeTiny-Assertion/basic.t
+++ b/t/20-unit/Error-TypeTiny-Assertion/basic.t
@@ -175,7 +175,7 @@ TODO: {
 			'Reference {1 => "1.1","2.2" => "2.3","3.3" => "3.4"} did not pass type constraint "Map[Int,Num]"',
 			'"Map[Int,Num]" constrains each key in the hash with "Int"',
 			'Value "2.2" did not pass type constraint "Int" (in key $_->{"2.2"})',
-			'"Int" is defined as: (defined $_ and $_ =~ /\A-?[0-9]+\z/)',
+			'"Int" is defined as: (defined($_) and !ref($_) and $_ =~ /\A-?[0-9]+\z/)',
 		],
 		'Map[Int,Num] deep explanation, given {1=>1.1,2.2=>2.3,3.3=>3.4}',
 	);

--- a/t/30-integration/Moo/exceptions.t
+++ b/t/30-integration/Moo/exceptions.t
@@ -48,6 +48,8 @@ BEGIN {
 my $e_constructor = exception { Goo->new(number => "too") };
 
 isa_ok($e_constructor, 'Error::TypeTiny::Assertion', '$e_constructor');
+# Expect the error message to contain this file, 'exceptions.t'
+like($e_constructor, qr/exceptions\.t/, '$e_constructor location');
 ok($e_constructor->has_attribute_name, '$e_constructor->has_attribute_name');
 is($e_constructor->attribute_name, 'number', '$e_constructor->attribute_name');
 ok($e_constructor->has_attribute_step, '$e_constructor->has_attribute_step');


### PR DESCRIPTION
This script in ./tinyMooErrorDemo.pl:

    #!/usr/bin/perl -w
    use strict;

    {
        package Foo;
        use Moo;
        use Types::Standard qw(Bool);
        has foo => ( is => 'ro', isa => Bool );
    }

    Foo->new(foo=>sub {});

Gave this output:

    Reference sub { "DUMMY" } did not pass type constraint "Bool" (in $args->{"foo"}) at (eval 62) line 59
        Reference sub { "DUMMY" } did not pass type constraint "Bool" (in $args->{"foo"})
        "Bool" is defined as: (Type::Tiny::XS::Bool($_))

With this commit, it now gives this output:

    Reference sub { "DUMMY" } did not pass type constraint "Bool" (in $args->{"foo"}) at ./tinyMooErrorDemo.pl line 11
        Reference sub { "DUMMY" } did not pass type constraint "Bool" (in $args->{"foo"})
        "Bool" is defined as: (Type::Tiny::XS::Bool($_))

Which makes more sense to the caller