### PR TITLE
allow Type::Coercion::add_type_coercions to accept Type::Coercion objects

### DIFF
--- a/lib/Type/Coercion.pm
+++ b/lib/Type/Coercion.pm
@@ -230,14 +230,23 @@ sub add_type_coercions
 	while (@args)
 	{
 		my $type     = Types::TypeTiny::to_TypeTiny(shift @args);
-		my $coercion = shift @args;
+
+                if ( blessed( $type ) and my $method = $type->can( 'type_coercion_map' ) ) {
+
+                    push @{$self->type_coercion_map}, @{$method->($type)};
+                }
+
+                else {
+
+                	my $coercion = shift @args;
 		
-		_croak "Types must be blessed Type::Tiny objects"
-			unless Types::TypeTiny::TypeTiny->check($type);
-		_croak "Coercions must be code references or strings"
-			unless Types::TypeTiny::StringLike->check($coercion) || Types::TypeTiny::CodeLike->check($coercion);
+			_croak "Types must be blessed Type::Tiny objects"
+				unless Types::TypeTiny::TypeTiny->check($type);
+			_croak "Coercions must be code references or strings"
+				unless Types::TypeTiny::StringLike->check($coercion) || Types::TypeTiny::CodeLike->check($coercion);
 		
-		push @{$self->type_coercion_map}, $type, $coercion;
+			push @{$self->type_coercion_map}, $type, $coercion;
+            }
 	}
 	
 	$self->_clear_compiled_coercion;

--- a/t/20-unit/Type-Coercion/basic.t
+++ b/t/20-unit/Type-Coercion/basic.t
@@ -181,4 +181,28 @@ should_fail({},      ArrayRef->coercibles);
 
 is($arrayref_from_piped->coercibles, $arrayref_from_piped->coercibles, '$arrayref_from_piped->coercibles == $arrayref_from_piped->coercibles');
 
+# ensure that add_type_coercion can handle Type::Coercions
+subtest 'add a Type::Coercion to a Type::Coercion' => sub {
+
+    my $coercion = Type::Coercion->new;
+    ok(
+        !$coercion->has_coercion_for_type( Str ),
+        "empty coercion can't coerce a Str"
+    );
+
+    is( exception { $coercion->add_type_coercions( ArrayRefFromPiped ) },
+        undef, "add a coercion from Str" );
+
+    ok(
+        $coercion->has_coercion_for_type( Str ),
+        "check that coercion was added"
+    );
+
+    # now see if coercion actually works
+    my $arrayref_from_piped = ArrayRef->plus_coercions($coercion);
+    my $coercibles          = $arrayref_from_piped->coercibles;
+    should_pass('1|2|3', $coercibles, "can coerce from a Str");
+};
+
+
 done_testing;


### PR DESCRIPTION
The documented API for the Type::Coercion::add_type_coercions method
indicates that one can pass it a Type::Coercion object.  This commit
adds that functionality.

