### PR TITLE
Minor correction to POD header

### DIFF
--- a/lib/Type/Params.pm
+++ b/lib/Type/Params.pm
@@ -1429,7 +1429,7 @@ any other Type::Tiny type constraints.
 
 =back
 
-=head1 Params::ValidationCompiler
+=head2 Params::ValidationCompiler
 
 L<Params::ValidationCompiler> does basically the same thing as
 L<Type::Params>.


### PR DESCRIPTION
Just spotted a minor POD heading issue, when reading the documentation. I think the [comparison part](https://metacpan.org/pod/release/TOBYINK/Type-Tiny-1.004002/lib/Type/Params.pm#COMPARISONS-WITH-OTHER-MODULES) starting with `=head1` _should_ hold two sub sections, beginning with `=head2`, but [the second one](https://metacpan.org/pod/release/TOBYINK/Type-Tiny-1.004002/lib/Type/Params.pm#Params::ValidationCompiler) is a `=head1` - that is if I am reading the documentation structure correctly.