### PR TITLE
carry through extra parameters when completing HalfOps

### DIFF
--- a/lib/Type/Library.pm
+++ b/lib/Type/Library.pm
@@ -91,7 +91,10 @@ sub _mksub
 		? sprintf(
 			q{
 				sub (%s) {
-					return $_[0]->complete($type) if ref($_[0]) eq 'Type::Tiny::_HalfOp';
+					if (ref($_[0]) eq 'Type::Tiny::_HalfOp') {
+						my $ho = shift;
+						return ($ho->complete($type), @_);
+					}
 					my $params; $params = shift if ref($_[0]) eq q(ARRAY);
 					my $t = $params ? $type->parameterize(@$params) : $type;
 					@_ && wantarray ? return($t%s, @_) : return $t%s;

--- a/t/20-unit/Type-Tiny-_HalfOp/extra-params.t
+++ b/t/20-unit/Type-Tiny-_HalfOp/extra-params.t
@@ -1,0 +1,44 @@
+=pod
+
+=encoding utf-8
+
+=head1 PURPOSE
+
+Ensure that the following works consistently on all supported Perls:
+
+    HashRef[Int]|Undef, @extra_parameters
+
+=head1 AUTHOR
+
+Graham Knop E<lt>haarg@cpan.orgE<gt>.
+
+=head1 COPYRIGHT AND LICENCE
+
+This software is copyright (c) 2020 by Graham Knop.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=cut
+
+use strict;
+use warnings FATAL => 'all';
+use Test::More;
+
+use Types::Standard -all;
+
+my $union = eval { Dict[ welp => HashRef[Int]|Undef, guff => ArrayRef[Int] ] };
+
+warn $union;
+
+SKIP: {
+	ok $union or skip 'broken type', 6;
+	ok $union->check({welp => {blorp => 1}, guff => [2]});
+	ok $union->check({welp => undef, guff => [2]});
+	ok $union->check({welp => {}, guff => []});
+	ok !$union->check({welp => {}, guff => {}});
+	ok !$union->check({welp => {blorp => 1}});
+	ok !$union->check({guff => [2]});
+}
+
+done_testing;


### PR DESCRIPTION
Parameterized type subs will receive one argument with their arguments,
but may also get additional arguments that they need to just add to the
list they return. The code that completes HalfOp combinations, which
handle the different precendence under perl < 5.14, wasn't accounting
for this, so some arguments could get lost.

Fixes RT#132455