### PR TITLE
Fix Type::Tiny->can and AUTOLOAD when the class "can't"

### DIFF
--- a/lib/Type/Tiny.pm
+++ b/lib/Type/Tiny.pm
@@ -1300,11 +1300,11 @@ sub can
 			my $method = $self->_lookup_my_method($1);
 			return $method if $method;
 		}
-	}
-
-	if ($self->{is_object} && $object_methods{$_[0]}) {
-		require Type::Tiny::ConstrainedObject;
-		return Type::Tiny::ConstrainedObject->can($_[0]);
+		if ($self->{is_object} && $object_methods{$_[0]})
+		{
+			require Type::Tiny::ConstrainedObject;
+			return Type::Tiny::ConstrainedObject->can($_[0]);
+		}
 	}
 	
 	return;
@@ -1328,13 +1328,13 @@ sub AUTOLOAD
 			my $method = $self->_lookup_my_method($1);
 			return &$method($self, @_) if $method;
 		}
-	}
-	
-	if ($self->{is_object} && $object_methods{$m}) {
-		require Type::Tiny::ConstrainedObject;
-		unshift @_, $self;
-		no strict 'refs';
-		goto \&{"Type::Tiny::ConstrainedObject::$m"};
+		if ($self->{is_object} && $object_methods{$m})
+		{
+			require Type::Tiny::ConstrainedObject;
+			unshift @_, $self;
+			no strict 'refs';
+			goto \&{"Type::Tiny::ConstrainedObject::$m"};
+		}
 	}
 	
 	_croak q[Can't locate object method "%s" via package "%s"], $m, ref($self)||$self;

--- a/t/20-unit/Type-Tiny/basic.t
+++ b/t/20-unit/Type-Tiny/basic.t
@@ -29,6 +29,12 @@ use Test::TypeTiny;
 
 use Type::Tiny;
 
+ok("Type::Tiny"->can('new'), 'Type::Tiny can works for valid methods');
+ok(
+	!"Type::Tiny"->can('will_never_be_a_method'),
+	'Type::Tiny can works for invalid methods'
+);
+
 my $Any = "Type::Tiny"->new(name => "Any");
 ok(!$Any->is_anon, "Any is not anon");
 is($Any->name, "Any", "Any is called Any");


### PR DESCRIPTION
Hi!  I caught this issue today after a dependency update.  The change introduced here:

https://github.com/tobyink/p5-type-tiny/commit/d11d043aa4ed44485f75f31f248f6d6c327da05a#diff-2d2f4240c6e6b48948f2efbb94166f60R1234

causes the following exception when can and AUTOLOAD are called as class methods and are falling through to return nada because they _can't_:

```
Can't use string ("Type::Tiny") as a HASH ref while "strict refs" in use at /usr/local/share/perl/5.26.1/Type/Tiny.pm line 1305.
        Type::Tiny::can("Type::Tiny", "foobaz") called at reply input line 1
```

AUTOLOAD hits the same thing rather than reaching the croak "Can't locate ..."

I added a test for can/can't cases, hopefully in a good spot, and then moved the entire offending section within the `if (ref($self))` just above it, in both methods.