### PR TITLE
Type::Library declare: Unshadow $t, allowing outer $t to be modified

### DIFF
--- a/lib/Type/Library.pm
+++ b/lib/Type/Library.pm
@@ -245,7 +245,7 @@ sub _exporter_fail
 			my $t;
 			
 			if ($type) {
-				my $t = $params ? $type->parameterize(@$params) : $type;
+				$t = $params ? $type->parameterize(@$params) : $type;
 			}
 			else
 			{


### PR DESCRIPTION
Hi again!  This one I'm afraid I don't have a test for; a coworker pointed it out to me and I didn't want it to get lost.  It looks like a stray 'my' was left here, shadowing the outer `$t` so this block doesn't have an effect.

I _think_ we tripped it when a `namespace::clean` was placed after the `-declare`, which doesn't make sense anyway, as those declared types aren't supposed to be removed.  One would expect a busted type library in that case, it just happened to work fine with an older Type::Tiny.  We fixed that, but this line still stood out as "_is this right?_"