### PR TITLE
Fixed typo in pod for Type::Tiny::Enum

### DIFF
--- a/lib/Type/Tiny/Enum.pm
+++ b/lib/Type/Tiny/Enum.pm
@@ -472,7 +472,7 @@ You can get a case-insensitive regexp using C<< $enum->as_regexp('i') >>.
 Returns the closest match in the enum for a string.
 
   my $enum = Type::Tiny::Enum->new(
-    value => [ qw( foo bar baz quux ) ],
+    values => [ qw( foo bar baz quux ) ],
   );
   
   say $enum->closest_match("FO");   # ==> foo
@@ -482,7 +482,7 @@ match, if it still can't find one, will try to find a head substring match,
 and finally, if given an integer, will use that as an index.
 
   my $enum = Type::Tiny::Enum->new(
-    value => [ qw( foo bar baz quux ) ],
+    values => [ qw( foo bar baz quux ) ],
   );
   
   say $enum->closest_match(  0 );  # ==> foo


### PR DESCRIPTION
I found trivial typo inside pod for `Type::Tiny::Enum`.

Example code seems to be broken due to typo.

Thanks!