### PR TITLE
Solved example that returned warning

### DIFF
--- a/lib/Types/Standard.pm
+++ b/lib/Types/Standard.pm
@@ -1511,7 +1511,7 @@ Here's an example using L<Regexp::Common>:
       has ip_address => (
          is         => 'ro',
          required   => 1,
-         isa        => StrMatch[/^$RE{net}{IPv4}$/],
+         isa        => StrMatch[qr/^$RE{net}{IPv4}$/],
          default    => '127.0.0.1',
       );
    }


### PR DESCRIPTION
Code:

    #!/usr/bin/perl
     
    use strict;
    use warnings;
     
    {
        package Test;
        use Moose;
        use Types::Standard qw/StrMatch/;
     
        # attribute ip
        has 'ip' => (
            is       => 'ro',
            required => 1,
            isa      => StrMatch[/^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/],
            default  => '127.0.0.1',
        );  
    }
   
    my $test = Test->new(ip => '0.0.0.0');

Warning:
Use of uninitialized value $_ in pattern match (m//) at test.pl line 12.