### PR TITLE
Correct `multisig` example given in documentation

### DIFF
--- a/lib/Type/Tiny/Manual/Params.pod
+++ b/lib/Type/Tiny/Manual/Params.pod
@@ -45,17 +45,17 @@ Multisig allows you to allow multiple ways of calling a sub.
  sub repeat_string {
    state $check = multisig(
      compile(
-       Int,
        Str,
+       Int,
      ),
      compile_named(
        { named_to_list => 1 },
-       count  => Int,
        string => Str,
+       count  => Int,
      ),
    );
-   
-   my ($count, $string) = $check->(@_);
+ 
+   my ($string, $count) = $check->(@_);
    return $string x $count;
  }
  


### PR DESCRIPTION
The example given have the `Str` and `Int` the wrong way round when the method is called.
Have updated the documentation to swap the `Str` and `Int` in the method definition.