### PR TITLE
Expand the Eval::TypeTiny API, moving stuff from Type::Library

### DIFF
--- a/lib/Type/Params.pm
+++ b/lib/Type/Params.pm
@@ -12,19 +12,13 @@ BEGIN {
 $Type::Params::VERSION =~ tr/_//d;
 
 use B qw();
-use Eval::TypeTiny;
-use Scalar::Util qw(refaddr);
+use Eval::TypeTiny qw( eval_closure set_subname );
+use Scalar::Util qw( refaddr );
 use Error::TypeTiny;
 use Error::TypeTiny::Assertion;
 use Error::TypeTiny::WrongNumberOfParameters;
 use Types::Standard ();
 use Types::TypeTiny ();
-
-BEGIN {
-	my $import1 = q{ require Sub::Util; Sub::Util->import( 'set_subname' ); 1 };
-	my $import2 = q{ require Sub::Name; *set_subname = \&Sub::Name::subname; 1 };
-	eval $import1 or eval $import2 or *set_subname = sub { pop; };
-};
 
 require Exporter::Tiny;
 our @ISA = 'Exporter::Tiny';

--- a/lib/Types/Standard.pm
+++ b/lib/Types/Standard.pm
@@ -20,7 +20,8 @@ use Type::Library -base;
 
 our @EXPORT_OK = qw( slurpy );
 
-use Scalar::Util qw( blessed looks_like_number );
+use Eval::TypeTiny  qw( set_subname );
+use Scalar::Util    qw( blessed looks_like_number );
 use Type::Tiny      ();
 use Types::TypeTiny ();
 
@@ -158,8 +159,6 @@ my $meta = __PACKAGE__->meta;
 	}
 	Types::Standard::_Stringable->Type::Tiny::_install_overloads(
 		q[""] => sub { $_[0]{text} ||= $_[0]{code}->() } );
-		
-	my $subname;
 	
 	sub LazyLoad ($$) {
 		bless \@_, 'Types::Standard::LazyLoad';
@@ -179,15 +178,10 @@ my $meta = __PACKAGE__->meta;
 			}
 			my $mm = $type->{my_methods} || {};
 			for my $key ( keys %$mm ) {
-				$subname =
-					eval   { require Sub::Util } ? \&Sub::Util::set_subname
-					: eval { require Sub::Name } ? \&Sub::Name::subname
-					: 0
-					if not defined $subname;
 				next unless ref( $mm->{$key} ) eq 'Types::Standard::LazyLoad';
 				my $f = $mm->{$key}[1];
 				$mm->{$key} = $class->can( "__$f" );
-				$subname and $subname->(
+				set_subname(
 					sprintf( "%s::my_%s", $type->qualified_name, $key ),
 					$mm->{$key},
 				);


### PR DESCRIPTION
Expand the Eval::TypeTiny API, bringing in some utility functions from Type::Library, cleaning them up, and documenting them (issue #116). This also has the effect of moving the `NICE_PROTOTYPES` constant, though it will still be available under the old name too.