### PR TITLE
Bitfield types

### DIFF
--- a/lib/Type/Tiny/Bitfield.pm
+++ b/lib/Type/Tiny/Bitfield.pm
@@ -191,12 +191,14 @@ sub to_string {
 }
 
 sub AUTOLOAD {
+	our $AUTOLOAD;
 	my $self = shift;
-	my ( $m ) = ( our $AUTOLOAD =~ /::(\w+)$/ );
+	my ( $m ) = ( $AUTOLOAD =~ /::(\w+)$/ );
 	return if $m eq 'DESTROY';
 	if ( ref $self and exists $self->{values}{$m} ) {
 		return 0 + $self->{values}{$m};
 	}
+	local $Type::Tiny::AUTOLOAD = $AUTOLOAD;
 	return $self->SUPER::AUTOLOAD( @_ );
 }
 
@@ -342,7 +344,7 @@ In the SYNOPSIS example, the coercion from B<Str> will accept strings like:
 =head2 Methods
 
 This class uses C<AUTOLOAD> to allow the names of each bit in the bitfield
-to be used as methods.
+to be used as methods. These method names will always be UPPER_SNAKE_CASE.
 
 For example, in the synopsis, C<< LedSet->GREEN >> would return 2.
 

--- a/lib/Type/Tiny/Bitfield.pm
+++ b/lib/Type/Tiny/Bitfield.pm
@@ -1,0 +1,146 @@
+package Type::Tiny::Bitfield;
+
+use 5.008001;
+use strict;
+use warnings;
+
+BEGIN {
+	$Type::Tiny::Bitfield::AUTHORITY = 'cpan:TOBYINK';
+	$Type::Tiny::Bitfield::VERSION   = '2.002001';
+}
+
+$Type::Tiny::Bitfield::VERSION =~ tr/_//d;
+
+sub _croak ($;@) { require Error::TypeTiny; goto \&Error::TypeTiny::croak }
+
+use Exporter::Tiny 1.004001 ();
+use Type::Tiny ();
+our @ISA = qw( Type::Tiny Exporter::Tiny );
+
+sub _is_power_of_two { not $_[0] & $_[0]-1 }
+
+sub _exporter_fail {
+	my ( $class, $type_name, $values, $globals ) = @_;
+	my $caller = $globals->{into};
+	my $type = $class->new(
+		name      => $type_name,
+		values    => { %$values },
+		#coercion  => 1,
+	);
+	$INC{'Type/Registry.pm'}
+		? 'Type::Registry'->for_class( $caller )->add_type( $type, $type_name )
+		: ( $Type::Registry::DELAYED{$caller}{$type_name} = $type )
+		unless( ref($caller) or $caller eq '-lexical' or $globals->{'lexical'} );
+	return map +( $_->{name} => $_->{code} ), @{ $type->exportables };
+}
+
+sub new {
+	my $proto = shift;
+	
+	my %opts = ( @_ == 1 ) ? %{ $_[0] } : @_;
+	_croak
+		"Bitfield type constraints cannot have a parent constraint passed to the constructor"
+		if exists $opts{parent};
+	_croak
+		"Bitfield type constraints cannot have a constraint coderef passed to the constructor"
+		if exists $opts{constraint};
+	_croak
+		"Bitfield type constraints cannot have a inlining coderef passed to the constructor"
+		if exists $opts{inlined};
+	_croak "Need to supply hashref of values"
+		unless exists $opts{values};
+	
+	require Types::Common::Numeric;
+	$opts{parent} = Types::Common::Numeric::PositiveOrZeroInt();
+	
+	my $ALL = 0;
+	my %already = ();
+	for my $value ( values %{ $opts{values} } ) {
+		_croak "Not a positive power of 2 in a bitfield: $value"
+			unless _is_power_of_two $value;
+		_croak "Duplicate value in a bitfield: $value"
+			if $already{$value}++;
+		$ALL |= ( 0 + $value );
+	}
+	$opts{ALL} = $ALL;
+	
+	# TODO: ensure all keys in $opt{values} are caps
+	
+	$opts{constraint} = sub {
+		not shift() & ~$ALL;
+	};
+	
+	# TODO: coercion
+	
+	return $proto->SUPER::new( %opts );
+} #/ sub new
+
+sub values {
+	$_[0]{values}
+}
+
+sub _lockdown {
+	my ( $self, $callback ) = @_;
+	$callback->( $self->{values} );
+}
+
+sub exportables {
+	my ( $self, $base_name ) = @_;
+	if ( not $self->is_anon ) {
+		$base_name ||= $self->name;
+	}
+	
+	my $exportables = $self->SUPER::exportables( $base_name );
+	
+	require Eval::TypeTiny;
+	require B;
+	
+	for my $key ( keys %{ $self->values } ) {
+		my $value = $self->values->{$key};
+		push @$exportables, {
+			name => uc( sprintf '%s_%s', $base_name, $key ),
+			tags => [ 'constants' ],
+			code => Eval::TypeTiny::eval_closure(
+				source      => sprintf( 'sub () { %d }', $value ),
+				environment => {},
+			),
+		};
+	}
+	
+	return $exportables;
+}
+
+sub can_be_inlined {
+	!!1;
+}
+
+sub inline_check {
+	my ( $self, $var ) = @_;
+	
+	return sprintf(
+		'( %s and not %s & ~%d )',
+		Types::Common::Numeric::PositiveOrZeroInt()->inline_check( $var ),
+		$var,
+		$self->{ALL},
+	);
+}
+
+sub AUTOLOAD {
+	my $self = shift;
+	my ( $m ) = ( our $AUTOLOAD =~ /::(\w+)$/ );
+	return if $m eq 'DESTROY';
+	if ( ref $self and exists $self->{values}{$m} ) {
+		return $self->{values}{$m};
+	}
+	return $self->SUPER::AUTOLOAD( @_ );
+}
+
+sub can {
+	my ( $self, $m ) = ( shift, @_ );
+	if ( ref $self and exists $self->{values}{$m} ) {
+		return sub () { $self->{values}{$m} };
+	}
+	return $self->SUPER::can( @_ );
+}
+
+1;

--- a/lib/Type/Tiny/Bitfield.pm
+++ b/lib/Type/Tiny/Bitfield.pm
@@ -179,7 +179,7 @@ sub from_string {
 
 sub to_string {
 	my ( $self, $int ) = @_;
-	is_PositiveOrZeroInt( $int ) or return;
+	$self->check( $int ) or return undef;
 	my %values = %{ $self->values };
 	$self->{all_names} ||= [ sort { $values{$a} <=> $values{$b} } keys %values ];
 	$int += 0;

--- a/lib/Type/Tiny/Bitfield.pm
+++ b/lib/Type/Tiny/Bitfield.pm
@@ -179,3 +179,205 @@ sub can {
 }
 
 1;
+
+
+__END__
+
+=pod
+
+=encoding utf-8
+
+=head1 NAME
+
+Type::Tiny::Bitfield - bitfield/bitflag type constraints
+
+=head1 SYNOPSIS
+
+Using Type::Tiny::Bitfield's export feature:
+
+  package LightSource {
+    use Moo;
+    
+    use Type::Tiny::Bitfield LedSet => {
+      RED   => 1,
+      GREEN => 2,
+      BLUE  => 4,
+    };
+    
+    has leds => ( is => 'ro', isa => LedSet, default => 0, coerce => 1 );
+    
+    sub new_red {
+      my $class = shift;
+      return $class->new( leds => LEDSET_RED );
+    }
+    
+    sub new_green {
+      my $class = shift;
+      return $class->new( leds => LEDSET_GREEN );
+    }
+    
+    sub new_yellow {
+      my $class = shift;
+      return $class->new( leds => LEDSET_RED | LEDSET_GREEN );
+    }
+  }
+
+Using Type::Tiny::Bitfield's object-oriented interface:
+
+  package LightSource {
+    use Moo;
+    use Type::Tiny::Bitfield;
+    
+    my $LedSet = Type::Tiny::Bitfield->new(
+      name   => 'LedSet',
+      values => {
+        RED   => 1,
+        GREEN => 2,
+        BLUE  => 4,
+      },
+      coercion => 1,
+    );
+    
+    has leds => ( is => 'ro', isa => $LedSet, default => 0, coerce => 1 );
+    
+    sub new_red {
+      my $class = shift;
+      return $class->new( leds => $LedSet->RED );
+    }
+    
+    sub new_green {
+      my $class = shift;
+      return $class->new( leds => $LedSet->GREEN );
+    }
+    
+    sub new_yellow {
+      my $class = shift;
+      return $class->new( leds => $LedSet->coerce('red|green') );
+    }
+  }
+
+=head1 STATUS
+
+This module is covered by the
+L<Type-Tiny stability policy|Type::Tiny::Manual::Policies/"STABILITY">.
+
+=head1 DESCRIPTION
+
+Bitfield type constraints.
+
+This package inherits from L<Type::Tiny>; see that for most documentation.
+Major differences are listed below:
+
+=head2 Attributes
+
+=over
+
+=item C<values>
+
+Hashref of bits allowed in the bitfield. Keys must be UPPER_SNAKE_CASE strings.
+Values must be positive integers which are powers of two. The same number
+cannot be used multiple times.
+
+=item C<constraint>
+
+Unlike Type::Tiny, you I<cannot> pass a constraint coderef to the constructor.
+Instead rely on the default.
+
+=item C<inlined>
+
+Unlike Type::Tiny, you I<cannot> pass an inlining coderef to the constructor.
+Instead rely on the default.
+
+=item C<parent>
+
+Parent is always B<Types::Common::Numeric::PositiveOrZeroInt>, and cannot be
+passed to the constructor.
+
+=item C<coercion>
+
+If C<< coercion => 1 >> is passed to the constructor, the type will have an
+automatic coercion from B<Str>. Types built by the C<import> method will
+always have C<< coercion => 1 >>.
+
+In the SYNOPSIS example, the coercion from B<Str> will accept strings like:
+
+  "RED"
+  "red"
+  "Red Green"
+  "Red+Blue"
+  "blue | GREEN"
+  "LEDSET_RED + LeDsEt_green"
+
+=back
+
+=head2 Methods
+
+This class uses C<AUTOLOAD> to allow the names of each bit in the bitfield
+to be used as methods.
+
+For example, in the synopsis, C<< LedSet->GREEN >> would return 2.
+
+=head2 Exports
+
+Type::Tiny::Bitfield can be used as an exporter.
+
+  use Type::Tiny::Bitfield LedSet => {
+    RED    => 1,
+    GREEN  => 2,
+    BLUE   => 4,
+  };
+
+This will export the following functions into your namespace:
+
+=over
+
+=item C<< LedSet >>
+
+=item C<< is_LedSet( $value ) >>
+
+=item C<< assert_LedSet( $value ) >>
+
+=item C<< to_LedSet( $value ) >>
+
+=item C<< LEDSET_RED >>
+
+=item C<< LEDSET_GREEN >>
+
+=item C<< LEDSET_BLUE >>
+
+=back
+
+Multiple bitfield types can be exported at once:
+
+  use Type::Tiny::Enum (
+    LedSet     => { RED => 1, GREEN => 2, BLUE => 4 },
+    LedPattern => [ FLASHING => 1 ],
+  );
+
+=head1 BUGS
+
+Please report any bugs to
+L<https://github.com/tobyink/p5-type-tiny/issues>.
+
+=head1 SEE ALSO
+
+L<Type::Tiny::Manual>.
+
+L<Type::Tiny>.
+
+=head1 AUTHOR
+
+Toby Inkster E<lt>tobyink@cpan.orgE<gt>.
+
+=head1 COPYRIGHT AND LICENCE
+
+This software is copyright (c) 2023 by Toby Inkster.
+
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.
+
+=head1 DISCLAIMER OF WARRANTIES
+
+THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
+MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.

--- a/lib/Type/Tiny/Bitfield.pm
+++ b/lib/Type/Tiny/Bitfield.pm
@@ -399,7 +399,7 @@ Multiple bitfield types can be exported at once:
 
   use Type::Tiny::Enum (
     LedSet     => { RED => 1, GREEN => 2, BLUE => 4 },
-    LedPattern => [ FLASHING => 1 ],
+    LedPattern => { FLASHING => 1 },
   );
 
 =head1 BUGS

--- a/t/20-modules/Type-Tiny-Bitfield/basic.t
+++ b/t/20-modules/Type-Tiny-Bitfield/basic.t
@@ -67,6 +67,13 @@ subtest 'Coercion from string' => sub {
 	is( to_LineStyle('reD | grEEn'), 5 );
 	is( to_LineStyle('green+blue'), 6 );
 	is( to_LineStyle('linestyle_dotted'), 64 );
+	is( LineStyle->from_string('reD | grEEn'), 5 );
+};
+
+subtest 'Coercion to string' => sub {
+	is( LineStyle->to_string( 6 ), 'BLUE|GREEN' );
+	is( LineStyle->to_string( 65 ), 'RED|DOTTED' );
+	is( LineStyle_to_Str( 65 ), 'RED|DOTTED' );
 };
 
 done_testing;

--- a/t/20-modules/Type-Tiny-Bitfield/basic.t
+++ b/t/20-modules/Type-Tiny-Bitfield/basic.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 
+use Types::Common qw( Str );
 use Type::Tiny::Bitfield LineStyle => {
 	RED    => 1,
 	BLUE   => 2,
@@ -56,7 +57,16 @@ subtest 'Bad bitfield naming' => sub {
 };
 
 ok( LineStyle->can_be_inlined, 'can be inlined' );
-
 note LineStyle->inline_check( '$VALUE' );
+
+subtest 'Coercion from string' => sub {
+	ok LineStyle->has_coercion;
+	ok LineStyle->coercion->has_coercion_for_type( Str );
+	is( to_LineStyle('reD'), 1 );
+	is( to_LineStyle('GREEN reD'), 5 );
+	is( to_LineStyle('reD | grEEn'), 5 );
+	is( to_LineStyle('green+blue'), 6 );
+	is( to_LineStyle('linestyle_dotted'), 64 );
+};
 
 done_testing;

--- a/t/20-modules/Type-Tiny-Bitfield/basic.t
+++ b/t/20-modules/Type-Tiny-Bitfield/basic.t
@@ -32,7 +32,7 @@ ok( !is_LineStyle( -4 ) );
 ok(  is_LineStyle( $_ ),  "is_LineStyle($_)" ) for 0, 1, 2, 3, 4, 5, 6, 7, 64, 65, 66, 67, 68, 69, 70, 71;
 ok( !is_LineStyle( $_ ), "!is_LineStyle($_)" ) for 8, 9, 10, 11, 12, 13, 14, 15, 62, 63, 72;
 
-{
+subtest 'Bad bitfield numbering' => sub {
 	local $@;
 	ok !eval q{
 		use Type::Tiny::Bitfield Abcdef => {
@@ -44,6 +44,15 @@ ok( !is_LineStyle( $_ ), "!is_LineStyle($_)" ) for 8, 9, 10, 11, 12, 13, 14, 15,
 		1;
 	};
 	like $@, qr/^Not a positive power of 2/, 'error message';
+};
+
+subtest 'Bad bitfield naming' => sub {
+	local $@;
+	ok !eval q{
+		use Type::Tiny::Bitfield Abcdef => { red => 1 };
+		1;
+	};
+	like $@, qr/^Not an all-caps name in a bitfield/, 'error message';
 };
 
 ok( LineStyle->can_be_inlined, 'can be inlined' );

--- a/t/20-modules/Type-Tiny-Bitfield/basic.t
+++ b/t/20-modules/Type-Tiny-Bitfield/basic.t
@@ -1,0 +1,53 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Type::Tiny::Bitfield LineStyle => {
+	RED    => 1,
+	BLUE   => 2,
+	GREEN  => 4,
+	DOTTED => 64,
+};
+
+is ( LINESTYLE_RED,  1, 'LINESTYLE_RED' );
+is ( LINESTYLE_BLUE,  2, 'LINESTYLE_BLUE' );
+is ( LINESTYLE_GREEN,  4, 'LINESTYLE_GREEN' );
+is ( LINESTYLE_DOTTED, 64, 'LINESTYLE_DOTTED' );
+
+is ( LineStyle->RED,  1, 'LineStyle->RED' );
+is ( LineStyle->BLUE,  2, 'LineStyle->BLUE' );
+is ( LineStyle->GREEN,  4, 'LineStyle->GREEN' );
+is ( LineStyle->DOTTED, 64, 'LineStyle->DOTTED' );
+
+ok( is_LineStyle( LINESTYLE_RED ), 'is_LineStyle( LINESTYLE_RED )' );
+
+my $RedDottedLine = LINESTYLE_RED | LINESTYLE_DOTTED;
+
+is( $RedDottedLine, 65 );
+ok( is_LineStyle( $RedDottedLine ) );
+
+ok( !is_LineStyle( 'RED' ) );
+ok( !is_LineStyle( -4 ) );
+
+ok(  is_LineStyle( $_ ),  "is_LineStyle($_)" ) for 0, 1, 2, 3, 4, 5, 6, 7, 64, 65, 66, 67, 68, 69, 70, 71;
+ok( !is_LineStyle( $_ ), "!is_LineStyle($_)" ) for 8, 9, 10, 11, 12, 13, 14, 15, 62, 63, 72;
+
+{
+	local $@;
+	ok !eval q{
+		use Type::Tiny::Bitfield Abcdef => {
+			RED    => 1,
+			BLUE   => 2,
+			GREEN  => 3,
+			DOTTED => 4,
+		};
+		1;
+	};
+	like $@, qr/^Not a positive power of 2/, 'error message';
+};
+
+ok( LineStyle->can_be_inlined, 'can be inlined' );
+
+note LineStyle->inline_check( '$VALUE' );
+
+done_testing;

--- a/t/20-modules/Type-Tiny-Bitfield/basic.t
+++ b/t/20-modules/Type-Tiny-Bitfield/basic.t
@@ -91,8 +91,11 @@ subtest 'Coercion from string' => sub {
 };
 
 subtest 'Coercion to string' => sub {
+	is( LineStyle->to_string( 2 ), 'BLUE' );
 	is( LineStyle->to_string( 6 ), 'BLUE|GREEN' );
 	is( LineStyle->to_string( 65 ), 'RED|DOTTED' );
+	is( LineStyle->to_string( [] ), undef );
+	is( LineStyle->to_string( -1 ), undef );
 	is( LineStyle_to_Str( 65 ), 'RED|DOTTED' );
 };
 

--- a/t/20-modules/Type-Tiny-Bitfield/basic.t
+++ b/t/20-modules/Type-Tiny-Bitfield/basic.t
@@ -1,8 +1,10 @@
 use strict;
 use warnings;
 use Test::More;
+use Test::Fatal;
+use Test::TypeTiny;
 
-use Types::Common qw( Str );
+use Types::Common qw( Str is_CodeRef );
 use Type::Tiny::Bitfield LineStyle => {
 	RED    => 1,
 	BLUE   => 2,
@@ -10,15 +12,33 @@ use Type::Tiny::Bitfield LineStyle => {
 	DOTTED => 64,
 };
 
-is ( LINESTYLE_RED,  1, 'LINESTYLE_RED' );
-is ( LINESTYLE_BLUE,  2, 'LINESTYLE_BLUE' );
-is ( LINESTYLE_GREEN,  4, 'LINESTYLE_GREEN' );
-is ( LINESTYLE_DOTTED, 64, 'LINESTYLE_DOTTED' );
+is( LineStyle->name, 'LineStyle' );
+is( LineStyle->parent->name, 'PositiveOrZeroInt' );
 
-is ( LineStyle->RED,  1, 'LineStyle->RED' );
-is ( LineStyle->BLUE,  2, 'LineStyle->BLUE' );
-is ( LineStyle->GREEN,  4, 'LineStyle->GREEN' );
-is ( LineStyle->DOTTED, 64, 'LineStyle->DOTTED' );
+should_pass( $_, LineStyle ) for 0, 1, 2, 3, 4, 5, 6, 7, 64, 65, 66, 67, 68, 69, 70, 71;
+should_fail( $_, LineStyle ) for 8, 9, 10, 11, 12, 13, 14, 15, 62, 63, 72;
+should_fail( 'RED', LineStyle );
+should_fail( -4, LineStyle );
+
+is( LINESTYLE_RED,  1, 'LINESTYLE_RED' );
+is( LINESTYLE_BLUE,  2, 'LINESTYLE_BLUE' );
+is( LINESTYLE_GREEN,  4, 'LINESTYLE_GREEN' );
+is( LINESTYLE_DOTTED, 64, 'LINESTYLE_DOTTED' );
+
+is( LineStyle->RED,  1, 'LineStyle->RED' );
+is( LineStyle->BLUE,  2, 'LineStyle->BLUE' );
+is( LineStyle->GREEN,  4, 'LineStyle->GREEN' );
+is( LineStyle->DOTTED, 64, 'LineStyle->DOTTED' );
+
+like(
+	exception { LineStyle->YELLOW },
+	qr/Can't locate object method "YELLOW" via package "Type::Tiny::Bitfield"/,
+	'LineStyle->YELLOW fails'
+);
+
+ok( is_CodeRef( LineStyle->can( 'RED' ) ), q{LineStyle->can( 'RED' )} );
+ok( !is_CodeRef( LineStyle->can( 'YELLOW' ) ), q{!LineStyle->can( 'YELLOW' )} );
+is( LineStyle->can( 'GREEN' )->(), 4, q{LineStyle->can( 'GREEN' )->()} );
 
 ok( is_LineStyle( LINESTYLE_RED ), 'is_LineStyle( LINESTYLE_RED )' );
 

--- a/t/20-modules/Type-Tiny-Bitfield/errors.t
+++ b/t/20-modules/Type-Tiny-Bitfield/errors.t
@@ -1,0 +1,58 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Fatal;
+
+use Type::Tiny::Bitfield;
+use Types::Common qw( ArrayRef );
+
+like(
+	exception {
+		Type::Tiny::Bitfield->new( parent => ArrayRef, values => {} ),
+	},
+	qr/cannot have a parent constraint passed to the constructor/i,
+);
+
+like(
+	exception {
+		Type::Tiny::Bitfield->new( constraint => sub { 0 }, values => {} ),
+	},
+	qr/cannot have a constraint coderef passed to the constructor/i,
+);
+
+like(
+	exception {
+		Type::Tiny::Bitfield->new( inlined => sub { 0 }, values => {} ),
+	},
+	qr/cannot have a inlining coderef passed to the constructor/i,
+);
+
+like(
+	exception {
+		Type::Tiny::Bitfield->new(),
+	},
+	qr/Need to supply hashref of values/i,
+);
+
+like(
+	exception {
+		Type::Tiny::Bitfield->new( values => { foo => 2 } ),
+	},
+	qr/Not an all-caps name in a bitfield/i,
+);
+
+like(
+	exception {
+		Type::Tiny::Bitfield->new( values => { FOO => 3 } ),
+	},
+	qr/Not a positive power of 2 in a bitfield/i,
+);
+
+like(
+	exception {
+		Type::Tiny::Bitfield->new( values => { FOO => 1, BAR => 1 } ),
+	},
+	qr/Duplicate value in a bitfield/i,
+);
+
+done_testing;

--- a/t/20-modules/Type-Tiny-Bitfield/import-options.t
+++ b/t/20-modules/Type-Tiny-Bitfield/import-options.t
@@ -1,0 +1,13 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Type::Tiny::Bitfield (
+	Colour  => { RED => 0x01, BLUE => 0x02, GREEN => 0x04, -prefix => 'My' },
+);
+
+is( MyColour->display_name, 'Colour' );
+
+is( MyCOLOUR_RED, 1 );
+
+done_testing;

--- a/t/20-modules/Type-Tiny-Bitfield/plus.t
+++ b/t/20-modules/Type-Tiny-Bitfield/plus.t
@@ -1,0 +1,87 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Fatal;
+use Test::TypeTiny;
+
+use Types::Standard qw( ArrayRef );
+use Type::Tiny::Bitfield (
+	Colour  => { RED => 0x01, BLUE => 0x02, GREEN => 0x04 },
+	Style   => { DOTTED => 0x08, ZIGZAG => 0x10, BLINK => 0x20 },
+);
+
+my $Combined = Colour + Style;
+
+ok( $Combined->isa('Type::Tiny::Bitfield'), "$Combined isa Type::Tiny::Bitfield" );
+is( $Combined->display_name, 'Colour+Style', "$Combined display_name" );
+ok( $Combined->is_anon, "$Combined is_anon" );
+
+should_pass( $_, $Combined ) for 0 .. 0x3F;
+should_fail( $_, $Combined ) for 0x40, 'BLEH', [], -1, undef, ArrayRef;
+
+is( $Combined->coerce( 'RED|GREEN|ZIGZAG' ), 21, 'coerce' );
+
+like(
+	exception {
+		my $x = Colour + ArrayRef;
+	},
+	qr/Bad overloaded operation/,
+	'Exception when trying to add Bitfield type and non-Bitfield type',
+);
+
+like(
+	exception {
+		my $x = ArrayRef() + Colour;
+	},
+	qr/Bad overloaded operation/,
+	'Exception when trying to add non-Bitfield type and Bitfield type',
+);
+
+like(
+	exception {
+		my $x = Colour + [];
+	},
+	qr/Bad overloaded operation/,
+	'Exception when trying to add Bitfield type and non-type',
+);
+
+like(
+	exception {
+		my $x = [] + Colour;
+	},
+	qr/Bad overloaded operation/,
+	'Exception when trying to add non-type and Bitfield type',
+);
+
+like(
+	exception {
+		my $x = Colour + Type::Tiny::Bitfield->new(
+			name   => 'Shape',
+			values => { CIRCLE => 0x40, BLUE => 0x80 },
+		);
+	},
+	qr/Conflicting value: BLUE/,
+	'Exception when trying to combine conflicting Bitfield types',
+);
+
+my $zzz = 0;
+sub combine_types_with_coercions {
+	my ( $x, $y ) = map {
+		my $coercion = $_;
+		++$zzz;
+		Type::Tiny::Bitfield->new(
+			values   => { "ZZZ$zzz" => 2 ** $zzz },
+			coercion => $coercion,
+		);
+	} @_;
+	return $x + $y;
+}
+
+subtest 'Combining Bitfield types with and without coercions works' => sub {
+	ok( ! combine_types_with_coercions( undef, undef )->has_coercion );
+	ok(   combine_types_with_coercions( undef, 1 )->has_coercion );
+	ok(   combine_types_with_coercions( 1, undef )->has_coercion );
+	ok(   combine_types_with_coercions( 1, 1 )->has_coercion );
+};
+
+done_testing;


### PR DESCRIPTION
For things like:

```perl
package MyApp::Line {
  use Moo;
  use Types::Common -types;
  
  use Type::Tiny::Bitfield LineStyle => {
    RED         => 1,
    GREEN       => 2,
    BLUE        => 4,
    DOTTED      => 64,
  };
  
  has [ 'start', 'end' ] => (
    is       => 'ro',
    isa      => InstanceOf[ 'MyApp::Point' ],
  );
  
  has style => (
    is       => 'ro',
    isa      => LineStyle,
    default  => 0,
  );
}

# A solid purple line from $p1 to $p2...
#
my $line = MyApp::Line->new(
  start    => $p1,
  end      => $p2,
  style    => MyApp::Line::LINESTYLE_RED | MyApp::Line::LINESTYLE_BLUE,
);

# A dotted green line:
#
my $s = MyApp::Line::LineStyle();
my $line2 = MyApp::Line->new(
  start    => $p3,
  end      => $p4,
  style    => $s->GREEN | $s->DOTTED,
);
```

Setting the `style` attribute to 8 would be a type error as there's no way to combine RED, BLUE, GREEN, and DOTTED to make 8.