### PR TITLE
Add check for Test::Moose in test

### DIFF
--- a/t/30-external/Moose/native-attribute-traits.t
+++ b/t/30-external/Moose/native-attribute-traits.t
@@ -29,6 +29,7 @@ the same terms as the Perl 5 programming language system itself.
 
 use Test::More;
 use Test::Requires { Moose => '2.1210' };
+use Test::Requires { 'Test::Moose' => '2.1210' };
 use Test::Fatal;
 use Test::TypeTiny qw( matchfor );
 use Test::Moose qw( with_immutable );


### PR DESCRIPTION
There is situation with Moose and without Test::Moose (split of runtime and testing envitonment).
e.g. Fedora installation via packages