### PR TITLE
XS for Int is faster inline

### DIFF
--- a/lib/Types/Standard.pm
+++ b/lib/Types/Standard.pm
@@ -112,6 +112,7 @@ my $add_core_type = sub {
 			# equivalents
 			$name eq 'Str'
 			or $name eq 'Bool'
+			or $name eq 'Int'
 			or $name eq 'ClassName'
 			or $name eq 'RegexpRef'
 			or $name eq 'FileHandle'

--- a/t/20-modules/Type-Params/strictness.t
+++ b/t/20-modules/Type-Params/strictness.t
@@ -22,6 +22,8 @@ the same terms as the Perl 5 programming language system itself.
 use strict;
 use warnings;
 
+BEGIN { $ENV{PERL_TYPE_TINY_XS} = 0; }
+
 use Test::More;
 use Test::Fatal;
 


### PR DESCRIPTION
As discussed on [Mastodon](https://fosstodon.org/@zmughal/110957915057334638),
this was determined using the following script:


```perl
#!/usr/bin/env perl

use Benchmark qw(cmpthese);
use Type::Tiny::XS;

print "$^V\n";
cmpthese(50_000_000, {
	regex => sub { my $my_val = '1000000'; die unless do { my $tmp = $my_val; defined($tmp) and !ref($tmp) and $tmp =~ /\A-?[0-9]+\z/ }  },
	xs    => sub { my $my_val = '1000000'; die unless Type::Tiny::XS::Int($my_val)  },
});
__END__
v5.38.0
            Rate regex    xs
regex  3351206/s    --  -76%
xs    14044944/s  319%    --
```
