### PR TITLE
Smartmatch discontinued beginning perl-5.41.3

### DIFF
--- a/lib/Type/Tiny.pm
+++ b/lib/Type/Tiny.pm
@@ -86,7 +86,7 @@ sub _croak ($;@) { require Error::TypeTiny; goto \&Error::TypeTiny::croak }
 sub _swap { $_[2] ? @_[ 1, 0 ] : @_[ 0, 1 ] }
 
 BEGIN {
-	my $support_smartmatch = 0+ !!( $] >= 5.010001 );
+	my $support_smartmatch = 0+ !!( $] >= 5.010001 && $] <= 5.041002 );
 	eval qq{ sub SUPPORT_SMARTMATCH () { !! $support_smartmatch } };
 	
 	my $fixed_precedence = 0+ !!( $] >= 5.014 );


### PR DESCRIPTION
This patch adapts Type-Tiny to changes in the Perl core distribution becoming effective with monthly dev release perl-5.41.3, anticipated for the coming week.  Please review and, if acceptable, issue a new CPAN release at your earliest opportunity, as that will be helpful for further automated testing of this distribution's many reverse dependencies.

Thank you very much.