### PR TITLE
check for Moose modules we interact with rather than Moose.pm

### DIFF
--- a/lib/Type/Coercion.pm
+++ b/lib/Type/Coercion.pm
@@ -469,14 +469,14 @@ sub _reparameterize {
 sub isa {
 	my $self = shift;
 	
-	if ( $INC{"Moose.pm"}
+	if ( $INC{"Moose/Meta/TypeCoercion.pm"}
 		and blessed( $self )
 		and $_[0] eq 'Moose::Meta::TypeCoercion' )
 	{
 		return !!1;
 	}
 	
-	if ( $INC{"Moose.pm"}
+	if ( $INC{"Moose/Meta/TypeCoercion.pm"}
 		and blessed( $self )
 		and $_[0] =~ /^(Class::MOP|MooseX?)::/ )
 	{
@@ -493,7 +493,7 @@ sub can {
 	my $can = $self->SUPER::can( @_ );
 	return $can if $can;
 	
-	if ( $INC{"Moose.pm"}
+	if ( $INC{"Moose/Meta/TypeCoercion.pm"}
 		and blessed( $self )
 		and my $method = $self->moose_coercion->can( @_ ) )
 	{
@@ -508,7 +508,7 @@ sub AUTOLOAD {
 	my ( $m ) = ( our $AUTOLOAD =~ /::(\w+)$/ );
 	return if $m eq 'DESTROY';
 	
-	if ( $INC{"Moose.pm"}
+	if ( $INC{"Moose/Meta/TypeCoercion.pm"}
 		and blessed( $self )
 		and my $method = $self->moose_coercion->can( $m ) )
 	{

--- a/lib/Type/Tiny.pm
+++ b/lib/Type/Tiny.pm
@@ -1446,7 +1446,7 @@ sub coercibles {
 sub isa {
 	my $self = shift;
 	
-	if ( $INC{"Moose.pm"}
+	if ( $INC{"Moose/Meta/TypeConstraint.pm"}
 		and ref( $self )
 		and $_[0] =~ /^(?:Class::MOP|MooseX?::Meta)::(.+)$/ )
 	{
@@ -1459,7 +1459,7 @@ sub isa {
 		
 		my $inflate = $self->moose_type;
 		return $inflate->isa( @_ );
-	} #/ if ( $INC{"Moose.pm"} ...)
+	} #/ if ( $INC{"Moose/Meta/TypeConstraint.pm"} ...)
 	
 	if ( $INC{"Mouse.pm"}
 		and ref( $self )
@@ -1507,7 +1507,7 @@ sub can {
 	return $can if $can;
 	
 	if ( ref( $self ) ) {
-		if ( $INC{"Moose.pm"} ) {
+		if ( $INC{"Moose/Meta/TypeConstraint.pm"} ) {
 			my $method = $self->moose_type->can( @_ );
 			return sub { shift->moose_type->$method( @_ ) }
 				if $method;
@@ -1538,7 +1538,7 @@ sub AUTOLOAD {
 	return if $m eq 'DESTROY';
 	
 	if ( ref( $self ) ) {
-		if ( $INC{"Moose.pm"} ) {
+		if ( $INC{"Moose/Meta/TypeConstraint.pm"} ) {
 			my $method = $self->moose_type->can( $m );
 			return $self->moose_type->$method( @_ ) if $method;
 		}

--- a/lib/Type/Utils.pm
+++ b/lib/Type/Utils.pm
@@ -503,7 +503,7 @@ sub classifier {
 	sub lookup_via_moose {
 		my $self = shift;
 		
-		if ( $INC{'Moose.pm'} ) {
+		if ( $INC{'Moose/Meta/TypeConstraint.pm'} ) {
 			require Moose::Util::TypeConstraints;
 			require Types::TypeTiny;
 			my $r = Moose::Util::TypeConstraints::find_type_constraint( $_[0] );
@@ -549,7 +549,7 @@ sub classifier {
 		
 		my $meta;
 		if ( defined $self->{"~~chained"} ) {
-			$meta ||= Moose::Util::find_meta( $self->{"~~chained"} ) if $INC{'Moose.pm'};
+			$meta ||= Moose::Util::find_meta( $self->{"~~chained"} ) if $INC{'Moose/Util.pm'};
 			$meta ||= Mouse::Util::find_meta( $self->{"~~chained"} ) if $INC{'Mouse.pm'};
 		}
 		


### PR DESCRIPTION
It's possible to create Moose types or coercions without loading Moose.pm. Instead of being conditional on Moose.pm being loaded, check for the actual modules we're trying to interact with, such as Moose::Meta::TypeCoercion.