### PR TITLE
avoid using Data::Dumper for Perl OBJECT refs

### DIFF
--- a/lib/Type/Tiny.pm
+++ b/lib/Type/Tiny.pm
@@ -76,7 +76,7 @@ our @InternalPackages = qw(
 	Type::Utils
 );
 
-use Scalar::Util qw( blessed );
+use Scalar::Util qw( blessed reftype blessed );
 use Types::TypeTiny ();
 
 our $SafePackage = sprintf 'package %s;', __PACKAGE__;
@@ -484,6 +484,7 @@ sub _dd {
 	
 	!defined $value  ? 'Undef'
 		: !ref $value ? sprintf( 'Value %s', B::perlstring( $value ) )
+                : reftype($value) eq 'OBJECT' ? sprintf( 'Object %s' . blessed( $value ) )
 		: do {
 		my $N = 0+ ( defined( $DD ) ? $DD : 72 );
 		require Data::Dumper;


### PR DESCRIPTION
Data::Dumper (at least as of 2.192, which is in the Perl git repo) doesn't support the new SVt_PVOBJ type, and generates a warning when it encounters it.  It does actually return something, but the warning can be quite annoying.

This commit special cases reftypes of 'OBJECT', avoiding use of Data::Dumper altogether.

An alternative might be to filter out warnings for SVt_PVOBJ, but that seems an iffy approach.

I didn't add a test, as I'm not quite sure where it should go.