### PR TITLE
ignore warnings issued by Data::Dumper

### DIFF
--- a/lib/Type/Tiny.pm
+++ b/lib/Type/Tiny.pm
@@ -494,6 +494,7 @@ sub _dd {
 		local $Data::Dumper::Maxdepth = 2;
 		my $str;
 		eval {
+                        local $SIG{__WARN__} = sub { };
 			$str = Data::Dumper::Dumper( $value );
 			$str = substr( $str, 0, $N - 12 ) . '...' . substr( $str, -1, 1 )
 				if length( $str ) >= $N;


### PR DESCRIPTION
Data::Dumper is used for generate textual representations of structures, not for serializing them, so any warnings it issues (e.g. unrecognized types, etc) do not provide actionable information to the user, and serve only to confuse and distract.